### PR TITLE
Fix iPad layout

### DIFF
--- a/iStorageWatcher/ContentView.swift
+++ b/iStorageWatcher/ContentView.swift
@@ -22,7 +22,26 @@ struct ContentView: View {
     
     var body: some View {
         #if os(iOS)
+        // Sidebar-based layout kept for reference
+        /*
         NavigationView {
+            VStack {
+                if let info = storageInfo {
+                    HomeView(storageInfo: info)
+                } else {
+                    Text(StorageWatcherStrings.fetchingStorageInfo.rawValue)
+                }
+                Spacer()
+            }
+            .navigationTitle(StorageWatcherStrings.appName.rawValue)
+        }
+        .onAppear {
+            storageInfo = StorageManager.shared.getStorageInfo()
+        }
+        */
+
+        // Use NavigationStack so the content appears in the main view on iPad
+        NavigationStack {
             VStack {
                 if let info = storageInfo {
                     HomeView(storageInfo: info)


### PR DESCRIPTION
## Summary
- keep old iOS sidebar code commented out
- show HomeView using `NavigationStack` so it appears in the main area on iPad

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688d61dceeac832ca9c1a64addf96d75